### PR TITLE
refactor: 移除写流 finish 事件的 end 调用

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -37,7 +37,6 @@ module.exports = ({ name, downloadUrl }) => {
     fileSteam.on('finish', () => {
       progress.stop()
       console.log(colors.green('文件下载完成'))
-      fileSteam.end()
       process.exit(0)
     })
   })


### PR DESCRIPTION
`finish` 时，写流的 `end` 已经被调用过一次了，反复调用是非必需的。具体可见 👉 [stream.html#event-finish](http://nodejs.cn/api/stream.html#event-finish)